### PR TITLE
Fix send email message variable

### DIFF
--- a/light/php/send-email.php
+++ b/light/php/send-email.php
@@ -22,8 +22,9 @@ if($_POST) {
 	if ($subject == '') { $subject = "Contact Form Submission"; }
 
    // Set Message
+   $message = '';
    $message .= "Email from: " . $name . "<br />";
-	 $message .= "Email address: " . $email . "<br />";
+         $message .= "Email address: " . $email . "<br />";
    $message .= "Message: <br />";
    $message .= nl2br($contact_message);
    $message .= "<br /> ----- <br /> This email was sent from your site " . url() . " contact form. <br />";


### PR DESCRIPTION
## Summary
- initialize `$message` before concatenating the email body

## Testing
- `php -l light/php/send-email.php`

------
https://chatgpt.com/codex/tasks/task_e_685011bad8a483288e538572261dc61e