### PR TITLE
Remove invalid form error container

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -551,8 +551,7 @@ var contactForm = function() {
 				email: "Please enter a valid email address",
 				message: "Please enter a message"
 			},
-			errorElement: 'span',
-			errorLabelContainer: '.form-error',
+                        errorElement: 'span',
 			/* submit via ajax */
 			submitHandler: function(form) {		
 				var $submit = $('.submitting'),

--- a/light/js/main.js
+++ b/light/js/main.js
@@ -551,8 +551,7 @@ var contactForm = function() {
 				email: "Please enter a valid email address",
 				message: "Please enter a message"
 			},
-			errorElement: 'span',
-			errorLabelContainer: '.form-error',
+                        errorElement: 'span',
 			/* submit via ajax */
 			submitHandler: function(form) {		
 				var $submit = $('.submitting'),


### PR DESCRIPTION
## Summary
- fix validation by removing references to a missing `.form-error` element

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685011be775c8328acdacaf5a2339bce